### PR TITLE
Document file-mode usage and uri_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,47 @@ du-process \
   --data '[{"src": "db:anno", "scheme": "transcript", "annotator": "test", "role": "testrole"}]'
 ```
 
+#### File mode (no database)
+
+Read inputs and write outputs directly from/to disk, without a NOVA database. Use `file:` sources and supply a path via `uri` (static, single session) or `uri_template` (per-session paths via `{dataset}` and `{session}` placeholders):
+
+```bash
+du-process \
+  --dataset "my_study" \
+  --trainer_file_path "path/to/trainer.trainer" \
+  --sessions '["session_a", "session_b"]' \
+  --data '[
+    {
+      "id": "video",
+      "type": "input",
+      "src": "file:stream:video",
+      "uri_template": "/data/{dataset}/{session}/video.mp4"
+    },
+    {
+      "id": "valence",
+      "type": "output",
+      "src": "file:annotation:continuous",
+      "uri_template": "/outputs/{dataset}/{session}/valence.annotation",
+      "sample_rate": 30,
+      "min_val": -1,
+      "max_val": 1
+    }
+  ]'
+```
+
+Each session resolves its own input and output paths. Output annotation descriptors may carry scheme metadata that is used when no annotation file exists yet:
+
+- `file:annotation:continuous`: `sample_rate`, `min_val`, `max_val` (defaults: `1`, `0`, `1`).
+- `file:annotation:discrete`: `classes` as an `{id: label}` map.
+
+This matters for modules that resample continuous outputs to the scheme's `sample_rate` — without explicit metadata, outputs default to 1 Hz.
+
+Notes:
+
+- `uri` and `uri_template` are filesystem paths (absolute or relative to the working directory). There is no implicit base directory.
+- `uri_template` placeholders that reference `{dataset}` or `{session}` must have non-empty values; otherwise `resolve_file_uri` raises `ValueError`.
+- `uri_template` takes precedence over `uri` when both are present.
+
 ### Python API
 
 ```python

--- a/README.md
+++ b/README.md
@@ -83,12 +83,16 @@ Each session resolves its own input and output paths. Output annotation descript
 - `file:annotation:continuous`: `sample_rate`, `min_val`, `max_val` (defaults: `1`, `0`, `1`).
 - `file:annotation:discrete`: `classes` as a map from class id to a dict of per-class XML attributes (typically `name`, optionally `color`, etc.). The outer key is the canonical id; the writer injects it into the XML automatically. For example:
 
-  ```json
+  ```jsonc
+  // fragment of a data description entry
   "classes": {
     "0": {"name": "neutral", "color": "#888"},
     "1": {"name": "happiness", "color": "#ffd700"}
   }
   ```
+
+  Legacy ``{id: name}`` strings are also accepted and normalized internally to the
+  canonical form.
 
 This matters for modules that resample continuous outputs to the scheme's `sample_rate` — without explicit metadata, outputs default to 1 Hz.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ du-process \
 Each session resolves its own input and output paths. Output annotation descriptors may carry scheme metadata that is used when no annotation file exists yet:
 
 - `file:annotation:continuous`: `sample_rate`, `min_val`, `max_val` (defaults: `1`, `0`, `1`).
-- `file:annotation:discrete`: `classes` as an `{id: label}` map.
+- `file:annotation:discrete`: `classes` as a map from class id to a dict of per-class XML attributes (typically `name`, optionally `color`, etc.). The outer key is the canonical id; the writer injects it into the XML automatically. For example:
+
+  ```json
+  "classes": {
+    "0": {"name": "neutral", "color": "#888"},
+    "1": {"name": "happiness", "color": "#ffd700"}
+  }
+  ```
 
 This matters for modules that resample continuous outputs to the scheme's `sample_rate` — without explicit metadata, outputs default to 1 Hz.
 

--- a/discover_utils/data/annotation.py
+++ b/discover_utils/data/annotation.py
@@ -84,11 +84,24 @@ class DiscreteAnnotationScheme(IAnnotationScheme):
     """
     Discrete annotation scheme class.
 
+    The ``classes`` mapping is keyed by class id and each value is itself a dict
+    of XML-attribute-style metadata for that class (typically at least ``name``,
+    optionally ``color``, ``isGarbage``, etc.). The outer key is the canonical
+    id; the writer injects it into the XML automatically, so the inner dict need
+    not repeat it.
+
+    Example::
+
+        {
+            "0": {"name": "neutral", "color": "#888"},
+            "1": {"name": "happiness", "color": "#ffd700"},
+        }
+
     Attributes:
-        classes (dict): Dictionary mapping class IDs to class names.
+        classes (dict): Dictionary mapping class IDs to per-class attribute dicts.
 
     Args:
-        classes (dict): Dictionary mapping class IDs to class names.
+        classes (dict): Dictionary mapping class IDs to per-class attribute dicts.
         *args: Variable length argument list.
         **kwargs: Arbitrary keyword arguments.
     """

--- a/discover_utils/data/annotation.py
+++ b/discover_utils/data/annotation.py
@@ -90,18 +90,27 @@ class DiscreteAnnotationScheme(IAnnotationScheme):
     id; the writer injects it into the XML automatically, so the inner dict need
     not repeat it.
 
+    For backward compatibility, plain string values are accepted and normalized to
+    ``{"name": <str>}`` at construction time, so legacy ``{id: name}`` configs still
+    work.
+
     Example::
 
+        # Canonical form
         {
             "0": {"name": "neutral", "color": "#888"},
             "1": {"name": "happiness", "color": "#ffd700"},
         }
 
+        # Legacy form, normalized internally to the canonical form
+        {"0": "neutral", "1": "happiness"}
+
     Attributes:
         classes (dict): Dictionary mapping class IDs to per-class attribute dicts.
 
     Args:
-        classes (dict): Dictionary mapping class IDs to per-class attribute dicts.
+        classes (dict): Dictionary mapping class IDs to per-class attribute dicts,
+            or to plain class-name strings (which are normalized to ``{"name": <str>}``).
         *args: Variable length argument list.
         **kwargs: Arbitrary keyword arguments.
     """
@@ -111,7 +120,10 @@ class DiscreteAnnotationScheme(IAnnotationScheme):
         Initialize a DiscreteAnnotationScheme instance with the provided class information.
         """
         super().__init__(*args, **kwargs)
-        self.classes = classes
+        self.classes = {
+            k: ({"name": v} if isinstance(v, str) else v)
+            for k, v in classes.items()
+        }
 
     @classmethod
     @property

--- a/discover_utils/data/handler/file_handler.py
+++ b/discover_utils/data/handler/file_handler.py
@@ -405,9 +405,12 @@ class _AnnotationFileHandler(IHandler):
                 attrib={"name": scheme_name, "type": scheme_type.name}
             )
             for class_id, class_attributes in data.annotation_scheme.classes.items():
-                Et.SubElement(
-                    scheme, "item", attrib={str(k): str(v) for k, v in class_attributes.items()}
-                )
+                # The outer key is the canonical class id; inject it as the "id" XML
+                # attribute so callers don't have to repeat it inside class_attributes.
+                # If both are present, the outer key wins.
+                attribs = {"id": str(class_id)}
+                attribs.update({str(k): str(v) for k, v in class_attributes.items() if k != "id"})
+                Et.SubElement(scheme, "item", attrib=attribs)
 
         elif scheme_type == SchemeType.CONTINUOUS:
             data: ContinuousAnnotation

--- a/discover_utils/data/provider/data_manager.py
+++ b/discover_utils/data/provider/data_manager.py
@@ -3,6 +3,7 @@ Author: Dominik Schiller <dominik.schiller@uni-a.de>
 Date: 25.10.2023
 """
 from pathlib import Path
+from string import Formatter
 from discover_utils.data.annotation import FreeAnnotation, FreeAnnotationScheme, ContinuousAnnotation, \
     ContinuousAnnotationScheme, DiscreteAnnotation, DiscreteAnnotationScheme
 from discover_utils.utils import path_utils
@@ -46,9 +47,13 @@ def resolve_file_uri(desc: dict, dataset: str | None, session: str | None) -> Pa
     """
     template = desc.get("uri_template")
     if template is not None:
-        if "{dataset}" in template and not dataset:
+        # Use Formatter().parse() to walk real format fields. This correctly handles
+        # escaped braces (``{{`` / ``}}``) and field specs (``{session:...}``) — substring
+        # checks would mis-classify both.
+        fields = {fname for _, fname, _, _ in Formatter().parse(template) if fname is not None}
+        if "dataset" in fields and not dataset:
             raise ValueError(f"uri_template references {{dataset}} but no dataset was provided: {template}")
-        if "{session}" in template and not session:
+        if "session" in fields and not session:
             raise ValueError(f"uri_template references {{session}} but no session was provided: {template}")
         return Path(template.format(dataset=dataset, session=session))
     if "uri" in desc:

--- a/discover_utils/data/provider/data_manager.py
+++ b/discover_utils/data/provider/data_manager.py
@@ -22,16 +22,25 @@ from discover_utils.utils.request_utils import Origin, SuperType, SubType, parse
 def resolve_file_uri(desc: dict, dataset: str, session: str) -> Path:
     """Resolve a file URI from a data description, supporting session-parameterized templates.
 
-    Checks for ``uri_template`` first (which may contain ``{dataset}`` and ``{session}``
-    placeholders), falling back to the plain ``uri`` field for backward compatibility.
+    Prefers ``uri_template`` (which may contain ``{dataset}`` and ``{session}`` placeholders)
+    over ``uri``. The plain ``uri`` field is returned verbatim and is never passed through
+    ``str.format``, so paths containing literal ``{`` characters are safe.
+
+    Both ``uri`` and ``uri_template`` are filesystem paths — absolute or relative to the
+    working directory — with no implicit base directory.
 
     Args:
-        desc (dict): Data description dictionary. May contain ``uri_template`` or ``uri``.
+        desc (dict): Data description dictionary. Must contain either ``uri_template`` or ``uri``.
         dataset (str): The dataset name used to fill ``{dataset}`` in the template.
         session (str): The session name used to fill ``{session}`` in the template.
 
     Returns:
         Path: Resolved file path.
+
+    Raises:
+        ValueError: If ``uri_template`` references ``{dataset}`` or ``{session}`` but the
+            corresponding argument is empty / ``None``.
+        KeyError: If neither ``uri_template`` nor ``uri`` is present in ``desc``.
     """
     template = desc.get("uri_template")
     if template is not None:
@@ -88,6 +97,10 @@ class SessionManager:
             To load a stream file from disk using data.handler.file_handler.FileHandler we only need a filepath
             ``"uri"``
                 The filepath from which to load the data from. Only necessary when loading files from disk.
+            ``"uri_template"``
+                Optional alternative to ``"uri"`` that supports ``{dataset}`` and ``{session}`` placeholders,
+                resolved per session via :func:`resolve_file_uri`. Takes precedence over ``"uri"`` when both
+                are set. Useful for batched multi-session jobs where each session has its own file path.
 
         session (str, optional): The name or title of the session.
         source_context (dict[str, dict]) : List of parameters that are need to interact with a source. E.g. database credentials or data directories. Must match constructor arguments of the respective data handler.
@@ -161,8 +174,12 @@ class SessionManager:
                 ``"role"``
                     The role to which the data belongs. Only necessary when accessing data from the database.
             To load a stream file from disk using data.handler.file_handler.FileHandler we only need a filepath
-            ``"fp"``
+            ``"uri"``
                 The filepath from which to load the data from. Only necessary when loading files from disk.
+            ``"uri_template"``
+                Optional alternative to ``"uri"`` that supports ``{dataset}`` and ``{session}`` placeholders,
+                resolved per session via :func:`resolve_file_uri`. Takes precedence over ``"uri"`` when both
+                are set.
 
         Returns:
 
@@ -329,9 +346,13 @@ class SessionManager:
                   The annotator of the annotations to load. Only necessary when loading annotations from the database.
               ``"role"``
                   The role to which the data belongs. Only necessary when accessing data from the database.
-          To load a stream file from disk using data.handler.file_handler.FileHandler we only need a filepath
-          ``"fp"``
-              The filepath from which to load the data from. Only necessary when loading files from disk.
+          To save a data object to disk using data.handler.file_handler.FileHandler we only need a filepath
+          ``"uri"``
+              The filepath to write the data to. Only necessary when saving files to disk.
+          ``"uri_template"``
+              Optional alternative to ``"uri"`` that supports ``{dataset}`` and ``{session}`` placeholders,
+              resolved per session via :func:`resolve_file_uri`. Takes precedence over ``"uri"`` when both
+              are set.
 
         Returns:
         """

--- a/discover_utils/data/provider/data_manager.py
+++ b/discover_utils/data/provider/data_manager.py
@@ -19,7 +19,7 @@ from discover_utils.utils.request_utils import Origin, SuperType, SubType, parse
     infer_dtype
 
 
-def resolve_file_uri(desc: dict, dataset: str, session: str) -> Path:
+def resolve_file_uri(desc: dict, dataset: str | None, session: str | None) -> Path:
     """Resolve a file URI from a data description, supporting session-parameterized templates.
 
     Prefers ``uri_template`` (which may contain ``{dataset}`` and ``{session}`` placeholders)
@@ -31,8 +31,10 @@ def resolve_file_uri(desc: dict, dataset: str, session: str) -> Path:
 
     Args:
         desc (dict): Data description dictionary. Must contain either ``uri_template`` or ``uri``.
-        dataset (str): The dataset name used to fill ``{dataset}`` in the template.
-        session (str): The session name used to fill ``{session}`` in the template.
+        dataset (str | None): The dataset name used to fill ``{dataset}`` in the template.
+            May be ``None`` if the template does not reference ``{dataset}``.
+        session (str | None): The session name used to fill ``{session}`` in the template.
+            May be ``None`` if the template does not reference ``{session}``.
 
     Returns:
         Path: Resolved file path.
@@ -310,7 +312,7 @@ class SessionManager:
                             data = DiscreteAnnotation(
                                 scheme=DiscreteAnnotationScheme(
                                     name='generic',
-                                    classes=desc.get('classes', {'1': 'class_one', '2': 'class_two'}),
+                                    classes=desc.get('classes', {'1': {'name': 'class_one'}, '2': {'name': 'class_two'}}),
                                 )
                             )
                         else:

--- a/tests/test_file_uri_resolution.py
+++ b/tests/test_file_uri_resolution.py
@@ -82,6 +82,20 @@ class TestResolveFileUri:
         result = resolve_file_uri(desc, dataset="ds", session="sess")
         assert result == Path("/data/weird{not_a_placeholder}/file.mp4")
 
+    def test_escaped_braces_in_template_do_not_count_as_placeholders(self):
+        # ``{{`` and ``}}`` are literal braces in a format string. They must not
+        # trigger the dataset/session placeholder validation.
+        desc = {"uri_template": "/data/{{dataset}}/{{session}}/file.mp4"}
+        result = resolve_file_uri(desc, dataset=None, session=None)
+        assert result == Path("/data/{dataset}/{session}/file.mp4")
+
+    def test_format_specs_on_placeholders_are_recognized(self):
+        # ``{session:>8}`` is a valid placeholder with a format spec; substring
+        # checks would miss it. The Formatter-based detection must catch it.
+        desc = {"uri_template": "/data/{session:>8}/file.mp4"}
+        with pytest.raises(ValueError):
+            resolve_file_uri(desc, dataset="ds", session=None)
+
 
 # ---------------------------------------------------------------------------
 # SessionManager.load() — two sessions load different paths via uri_template
@@ -247,18 +261,36 @@ class TestOutputAnnotationMetadata:
         anno = sm.output_data_templates["valence"]
         assert anno.annotation_scheme.sample_rate == 1
 
-    def test_discrete_template_uses_classes_from_desc(self):
-        classes = {"0": "neutral", "1": "happiness", "2": "sadness"}
+    def test_discrete_template_uses_classes_from_desc_canonical(self):
+        classes = {
+            "0": {"name": "neutral", "color": "#888"},
+            "1": {"name": "happiness"},
+        }
         desc_override = {
             "id": "expression",
             "src": "file:annotation:discrete",
             "classes": classes,
         }
         sm = self._load_output_template(desc_override)
-        # Key is "expression" because we overrode id
         anno = sm.output_data_templates["expression"]
         assert isinstance(anno, DiscreteAnnotation)
         assert anno.annotation_scheme.classes == classes
+
+    def test_discrete_template_normalizes_legacy_string_classes(self):
+        legacy = {"0": "neutral", "1": "happiness", "2": "sadness"}
+        desc_override = {
+            "id": "expression",
+            "src": "file:annotation:discrete",
+            "classes": legacy,
+        }
+        sm = self._load_output_template(desc_override)
+        anno = sm.output_data_templates["expression"]
+        assert isinstance(anno, DiscreteAnnotation)
+        assert anno.annotation_scheme.classes == {
+            "0": {"name": "neutral"},
+            "1": {"name": "happiness"},
+            "2": {"name": "sadness"},
+        }
 
     def test_discrete_template_defaults_when_no_classes_in_desc(self):
         desc_override = {
@@ -270,3 +302,61 @@ class TestOutputAnnotationMetadata:
         assert isinstance(anno, DiscreteAnnotation)
         # Default classes should be present
         assert len(anno.annotation_scheme.classes) > 0
+
+
+# ---------------------------------------------------------------------------
+# FileHandler.save() — discrete scheme XML id-injection
+# ---------------------------------------------------------------------------
+
+class TestDiscreteSchemeIdInjection:
+    """Verifies that the writer injects the canonical class id from the outer
+    dict key into the XML, so callers don't need to repeat it inside the
+    per-class attribute dict."""
+
+    def _save_and_parse(self, classes: dict, tmp_path: Path):
+        import numpy as np
+        import xml.etree.ElementTree as Et
+        from discover_utils.data.handler.file_handler import FileHandler
+
+        scheme = DiscreteAnnotationScheme(name="emotion", classes=classes)
+        data = np.array([], dtype=scheme.label_dtype)
+        anno = DiscreteAnnotation(data=data, scheme=scheme)
+        fp = tmp_path / "out.annotation"
+        FileHandler().save(data=anno, fp=fp)
+        # The XML lives at fp; the binary data lives at fp + "~"
+        return Et.parse(fp).getroot()
+
+    def test_id_injected_from_outer_key_when_missing_inside(self, tmp_path):
+        classes = {
+            "0": {"name": "neutral"},
+            "1": {"name": "happiness", "color": "#ffd700"},
+        }
+        root = self._save_and_parse(classes, tmp_path)
+        items = root.findall("./scheme/item")
+        assert {it.get("id"): it.get("name") for it in items} == {
+            "0": "neutral",
+            "1": "happiness",
+        }
+        color_by_id = {it.get("id"): it.get("color") for it in items}
+        assert color_by_id["1"] == "#ffd700"
+
+    def test_outer_key_wins_over_inner_id(self, tmp_path):
+        # If the inner dict carries a (potentially stale) id, the outer key
+        # must win — the outer dict is the single source of truth.
+        classes = {
+            "0": {"id": "999", "name": "neutral"},
+            "1": {"id": "888", "name": "happiness"},
+        }
+        root = self._save_and_parse(classes, tmp_path)
+        ids = sorted(it.get("id") for it in root.findall("./scheme/item"))
+        assert ids == ["0", "1"]
+
+    def test_legacy_string_classes_are_coerced_and_serialize(self, tmp_path):
+        # Legacy {id: name_str} form should be normalized at scheme construction
+        # and round-trip cleanly through the writer.
+        classes = {"0": "neutral", "1": "happiness"}
+        root = self._save_and_parse(classes, tmp_path)
+        assert {it.get("id"): it.get("name") for it in root.findall("./scheme/item")} == {
+            "0": "neutral",
+            "1": "happiness",
+        }


### PR DESCRIPTION
Follow-up to #4 — adds user-facing docs for the file-mode + ``uri_template`` feature, plus a small set of code fixes that surfaced during review.

## Documentation

- **`README.md`**: new *File mode (no database)* subsection under *Getting Started* with a multi-session ``du-process`` example, output annotation metadata fields (``sample_rate`` / ``min_val`` / ``max_val`` / ``classes``), and notes on path resolution and placeholder validation.
- **`resolve_file_uri` docstring**: drop the misleading "backward compatibility" wording, document the no-implicit-base-dir contract, and add a ``Raises:`` section.
- **`SessionManager.load` / ``.save`` schema docstrings**: replace the stale ``"fp"`` field name with ``"uri"`` and add a ``"uri_template"`` entry.
- **`DiscreteAnnotationScheme` docstring**: rewrite to document the actual ``{id: attr_dict}`` format with a concrete example, replacing the long-stale ``{id: name}`` wording.

## Code / behavior changes

These started as docs work but turned up real bugs and stale defaults. All changes preserve existing on-disk artefacts.

- **`resolve_file_uri` signature**: ``dataset`` and ``session`` typed as ``str | None`` (the docstring already documented they may be ``None`` when the template does not reference the corresponding placeholder).
- **`resolve_file_uri` placeholder detection**: replace substring checks with ``string.Formatter().parse()`` so escaped braces (``{{...}}``) and field specs (``{session:spec}``) are handled correctly.
- **`file_handler.py` discrete writer**: inject the canonical class id from the outer ``classes`` dict key into the XML ``<item id="...">`` attribute. Old descriptors that already carry an inner ``"id"`` produce identical XML (outer key wins). Lets users write the cleaner ``{id: {"name": ...}}`` form without repeating the id.
- **`DiscreteAnnotationScheme.__init__`**: normalize legacy ``{id: name_str}`` configs to the canonical ``{id: {"name": name_str}}`` form at construction time. Previously such configs would crash the file writer with ``AttributeError: 'str' object has no attribute 'items'``.
- **`SessionManager` discrete fallback default**: switched from ``{'1': 'class_one'}`` (would crash on save) to ``{'1': {'name': 'class_one'}}``. (Even with the new coercion above the canonical form is the right default.)

## Tests

23/23 pass. New coverage added for:

- ``resolve_file_uri`` Formatter edge cases (escaped braces, field specs).
- ``DiscreteAnnotationScheme`` legacy-string normalization.
- ``FileHandler.save`` discrete-scheme XML id-injection / outer-key-wins / legacy-classes round-trip.