### PR TITLE
Add DB exploration queries; optimize annotation load path

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,36 @@ dm = DatasetManager(
 )
 ```
 
+#### Exploring a database
+
+When you don't already know the dataset, scheme, or annotator names, use the
+exploration queries on the MongoDB handler to discover what's available. They are
+read-only and return lightweight metadata (no stream files or annotation labels are
+loaded):
+
+```python
+from discover_utils.data.handler.nova_db_handler import NovaDBHandler
+
+db = NovaDBHandler(
+    db_host="127.0.0.1", db_port=27017, db_user="user", db_password="pass",
+)
+
+db.list_datasets()                      # datasets you can read
+db.list_sessions("my_dataset")          # session names
+db.list_scheme_names("my_dataset")      # scheme names
+db.list_schemes("my_dataset")           # [{name, type}, ...]
+db.list_roles("my_dataset")             # role names
+db.list_annotators("my_dataset")        # annotator names
+db.list_streams("my_dataset")           # stream metadata (no files read)
+
+# which annotations exist for a session, without loading any labels
+db.list_annotations("my_dataset", session="session1")
+# -> [{session, annotator, role, scheme, isFinished, isLocked}, ...]
+```
+
+The same methods are inherited by `AnnotationHandler`, `StreamHandler`, and
+`SessionHandler`, so you can explore and load through a single handler instance.
+
 ## Documentation
 
 Full API documentation is available at [hcmlab.github.io/discover-utils/docbuild/](https://hcmlab.github.io/discover-utils/docbuild/).

--- a/discover_utils/__init__.py
+++ b/discover_utils/__init__.py
@@ -9,8 +9,8 @@ Date:
 """
 
 _MAJOR_VERSION = '1'
-_MINOR_VERSION = '1'
-_PATCH_VERSION = '1'
+_MINOR_VERSION = '2'
+_PATCH_VERSION = '0'
 
 __version__ = '.'.join([
     _MAJOR_VERSION,

--- a/discover_utils/data/handler/nova_db_handler.py
+++ b/discover_utils/data/handler/nova_db_handler.py
@@ -279,7 +279,7 @@ class NovaDBHandler:
         List the annotation schemes of a dataset as lightweight metadata.
 
         Returns name and type only - the (potentially large) labels/attributes payload
-        is not loaded. Use AnnotationHandler.load(..., header_only=True) for a full scheme.
+        is not loaded.
         """
         return list(
             self._require_client()[dataset][SCHEME_COLLECTION].find(
@@ -326,14 +326,23 @@ class NovaDBHandler:
             list[dict]: One dict per annotation with keys
                 'session', 'annotator', 'role', 'scheme', 'isFinished', 'isLocked'.
         """
-        pipeline = [
+        db = self._require_client()[dataset]
+
+        pipeline = []
+        # filter on session_id BEFORE the joins so the lookups only run on the
+        # session's annotations, not the whole collection
+        if session is not None:
+            session_doc = db[SESSION_COLLECTION].find_one({"name": session}, {"_id": 1})
+            if not session_doc:
+                return []
+            pipeline.append({"$match": {"session_id": session_doc["_id"]}})
+
+        pipeline += [
             {"$lookup": {"from": SESSION_COLLECTION, "localField": "session_id", "foreignField": "_id", "as": "session"}},
             {"$lookup": {"from": ANNOTATOR_COLLECTION, "localField": "annotator_id", "foreignField": "_id", "as": "annotator"}},
             {"$lookup": {"from": ROLE_COLLECTION, "localField": "role_id", "foreignField": "_id", "as": "role"}},
             {"$lookup": {"from": SCHEME_COLLECTION, "localField": "scheme_id", "foreignField": "_id", "as": "scheme"}},
         ]
-        if session is not None:
-            pipeline.append({"$match": {"session.name": session}})
         pipeline.append(
             {
                 "$project": {
@@ -347,7 +356,7 @@ class NovaDBHandler:
                 }
             }
         )
-        return list(self._require_client()[dataset][ANNOTATION_COLLECTION].aggregate(pipeline))
+        return list(db[ANNOTATION_COLLECTION].aggregate(pipeline))
 
 
 class NovaSession:
@@ -520,7 +529,7 @@ class AnnotationHandler(IHandler, NovaDBHandler):
             return anno
 
         anno = db[ANNOTATION_COLLECTION].find_one(query)
-        if not anno:
+        if not anno or not anno.get("data_id"):
             return {}
 
         # fetch the annotation data payload only for the matched annotation

--- a/discover_utils/data/handler/nova_db_handler.py
+++ b/discover_utils/data/handler/nova_db_handler.py
@@ -541,6 +541,10 @@ class AnnotationHandler(IHandler, NovaDBHandler):
 
         # fetch the full scheme document (by id, indexed) only on the non-projected path
         scheme_doc = db[SCHEME_COLLECTION].find_one({"_id": scheme_id["_id"]})
+        if not scheme_doc:
+            # scheme deleted after name->id resolution (inconsistent DB) - treat as
+            # not found so callers raise FileNotFoundError instead of crashing
+            return {}
 
         # reproduce the previous aggregate output shape for the caller
         anno["data"] = [data_doc]

--- a/discover_utils/data/handler/nova_db_handler.py
+++ b/discover_utils/data/handler/nova_db_handler.py
@@ -224,6 +224,131 @@ class NovaDBHandler:
         """
         return self._client
 
+    def _require_client(self) -> MongoClient:
+        """Return the MongoDB client or raise a clear error if not connected."""
+        if self._client is None:
+            raise ConnectionError(
+                "Not connected to a MongoDB database. Provide db_host/db_port/db_user/db_password or call connect() first."
+            )
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Exploration queries
+    #
+    # Read-only enumeration helpers to discover what exists in the database
+    # without knowing exact names up front. Available on every handler via
+    # inheritance; for pure exploration a plain NovaDBHandler can be used.
+    # ------------------------------------------------------------------
+    def list_datasets(self, nova_only: bool = True) -> list[str]:
+        """
+        List the names of all datasets (databases) the connected user can read.
+
+        Args:
+            nova_only (bool): If True (default), only return databases that look like
+                NOVA datasets (those containing a 'Sessions' collection), excluding
+                MongoDB's internal 'admin'/'config'/'local' databases. If False, return
+                all readable databases except the internal ones.
+
+        Returns:
+            list[str]: Dataset names.
+        """
+        client = self._require_client()
+        system_dbs = {"admin", "config", "local"}
+        datasets = [db for db in client.list_database_names() if db not in system_dbs]
+        if nova_only:
+            datasets = [
+                db for db in datasets
+                if SESSION_COLLECTION in client[db].list_collection_names()
+            ]
+        return datasets
+
+    def list_sessions(self, dataset: str) -> list[str]:
+        """
+        List the session names of a dataset.
+
+        Lightweight names-only query. For full session objects use SessionHandler.load.
+        """
+        return self._require_client()[dataset][SESSION_COLLECTION].distinct("name")
+
+    def list_scheme_names(self, dataset: str) -> list[str]:
+        """List the annotation scheme names of a dataset."""
+        return self._require_client()[dataset][SCHEME_COLLECTION].distinct("name")
+
+    def list_schemes(self, dataset: str) -> list[dict]:
+        """
+        List the annotation schemes of a dataset as lightweight metadata.
+
+        Returns name and type only - the (potentially large) labels/attributes payload
+        is not loaded. Use AnnotationHandler.load(..., header_only=True) for a full scheme.
+        """
+        return list(
+            self._require_client()[dataset][SCHEME_COLLECTION].find(
+                {}, {"name": 1, "type": 1, "_id": 0}
+            )
+        )
+
+    def list_roles(self, dataset: str) -> list[str]:
+        """List the role names of a dataset."""
+        return self._require_client()[dataset][ROLE_COLLECTION].distinct("name")
+
+    def list_annotators(self, dataset: str) -> list[str]:
+        """List the annotator names of a dataset."""
+        return self._require_client()[dataset][ANNOTATOR_COLLECTION].distinct("name")
+
+    def list_streams(self, dataset: str) -> list[dict]:
+        """
+        List the streams of a dataset as lightweight metadata.
+
+        Returns stream metadata only (name, type, sample rate, dim labels, file
+        extension, validity). No stream file is read from disk.
+        """
+        return list(
+            self._require_client()[dataset][STREAM_COLLECTION].find(
+                {},
+                {"name": 1, "type": 1, "sr": 1, "dimlabels": 1, "fileExt": 1, "isValid": 1, "_id": 0},
+            )
+        )
+
+    def list_annotations(self, dataset: str, session: str = None) -> list[dict]:
+        """
+        List the annotations of a dataset (optionally filtered to one session) as
+        metadata only.
+
+        Returns the session/annotator/role/scheme combinations that exist, together
+        with isFinished/isLocked flags. The annotation data payload is deliberately
+        NOT loaded - this answers "what annotations exist" without pulling any labels.
+
+        Args:
+            dataset (str): Name of the dataset.
+            session (str, optional): If given, only annotations of this session are returned.
+
+        Returns:
+            list[dict]: One dict per annotation with keys
+                'session', 'annotator', 'role', 'scheme', 'isFinished', 'isLocked'.
+        """
+        pipeline = [
+            {"$lookup": {"from": SESSION_COLLECTION, "localField": "session_id", "foreignField": "_id", "as": "session"}},
+            {"$lookup": {"from": ANNOTATOR_COLLECTION, "localField": "annotator_id", "foreignField": "_id", "as": "annotator"}},
+            {"$lookup": {"from": ROLE_COLLECTION, "localField": "role_id", "foreignField": "_id", "as": "role"}},
+            {"$lookup": {"from": SCHEME_COLLECTION, "localField": "scheme_id", "foreignField": "_id", "as": "scheme"}},
+        ]
+        if session is not None:
+            pipeline.append({"$match": {"session.name": session}})
+        pipeline.append(
+            {
+                "$project": {
+                    "_id": 0,
+                    "session": {"$arrayElemAt": ["$session.name", 0]},
+                    "annotator": {"$arrayElemAt": ["$annotator.name", 0]},
+                    "role": {"$arrayElemAt": ["$role.name", 0]},
+                    "scheme": {"$arrayElemAt": ["$scheme.name", 0]},
+                    "isFinished": 1,
+                    "isLocked": 1,
+                }
+            }
+        )
+        return list(self._require_client()[dataset][ANNOTATION_COLLECTION].aggregate(pipeline))
+
 
 class NovaSession:
     """
@@ -355,69 +480,55 @@ class AnnotationHandler(IHandler, NovaDBHandler):
             project (dict, optional): Projection for MongoDB query to filter attributes. Defaults to None.
 
         Returns:
-            dict: Loaded annotation data.
+            dict: Loaded annotation data. When ``project`` is None the returned dict
+                mirrors the previous aggregate shape, exposing ``data`` and ``scheme``
+                as single-item lists (``[data_doc]`` / ``[scheme_doc]``). When
+                ``project`` is given, the projection is applied to the annotation
+                document and the ``data``/``scheme`` documents are not fetched.
+
+        Notes:
+            Resolves the session/annotator/role/scheme names to their ids via indexed
+            ``find_one`` lookups, then fetches the single matching annotation by id -
+            avoiding a collection-wide ``$lookup`` join across all annotations. The
+            large ``AnnotationData`` payload is only read for the matched annotation.
+            Mirrors the id-resolution pattern used in ``save``.
         """
-        pipeline = [
-            {
-                "$lookup": {
-                    "from": SESSION_COLLECTION,
-                    "localField": "session_id",
-                    "foreignField": "_id",
-                    "as": "session",
-                }
-            },
-            {
-                "$lookup": {
-                    "from": ANNOTATOR_COLLECTION,
-                    "localField": "annotator_id",
-                    "foreignField": "_id",
-                    "as": "annotator",
-                }
-            },
-            {
-                "$lookup": {
-                    "from": ROLE_COLLECTION,
-                    "localField": "role_id",
-                    "foreignField": "_id",
-                    "as": "role",
-                }
-            },
-            {
-                "$lookup": {
-                    "from": SCHEME_COLLECTION,
-                    "localField": "scheme_id",
-                    "foreignField": "_id",
-                    "as": "scheme",
-                }
-            },
-            {
-                "$match": {
-                    "$and": [
-                        {"role.name": role},
-                        {"session.name": session},
-                        {"annotator.name": annotator},
-                        {"scheme.name": scheme},
-                    ]
-                }
-            },
-            {
-                "$lookup": {
-                    "from": "AnnotationData",
-                    "localField": "data_id",
-                    "foreignField": "_id",
-                    "as": "data",
-                }
-            },
-        ]
+        db = self.client[dataset]
 
-        # append projection
-        if project:
-            pipeline.append({"$project": project})
+        # resolve names -> ids (indexed single-document lookups)
+        scheme_doc = db[SCHEME_COLLECTION].find_one({"name": scheme})
+        session_id = db[SESSION_COLLECTION].find_one({"name": session}, {"_id": 1})
+        role_id = db[ROLE_COLLECTION].find_one({"name": role}, {"_id": 1})
+        annotator_id = db[ANNOTATOR_COLLECTION].find_one({"name": annotator}, {"_id": 1})
 
-        result = list(self.client[dataset][ANNOTATION_COLLECTION].aggregate(pipeline))
-        if not result:
+        if not (scheme_doc and session_id and role_id and annotator_id):
             return {}
-        return result[0]
+
+        query = {
+            "session_id": session_id["_id"],
+            "annotator_id": annotator_id["_id"],
+            "role_id": role_id["_id"],
+            "scheme_id": scheme_doc["_id"],
+        }
+
+        # projected reads (e.g. existence check in save) only need annotation fields
+        if project:
+            anno = db[ANNOTATION_COLLECTION].find_one(query, project)
+            if not anno:
+                return {}
+            return anno
+
+        anno = db[ANNOTATION_COLLECTION].find_one(query)
+        if not anno:
+            return {}
+
+        # fetch the annotation data payload only for the matched annotation
+        data_doc = db[ANNOTATION_DATA_COLLECTION].find_one({"_id": anno["data_id"]})
+
+        # reproduce the previous aggregate output shape for the caller
+        anno["data"] = [data_doc]
+        anno["scheme"] = [scheme_doc]
+        return anno
 
     def _load_scheme(self, dataset: str, scheme: str) -> dict:
         result = self.client[dataset][SCHEME_COLLECTION].find_one({"name": scheme})

--- a/discover_utils/data/handler/nova_db_handler.py
+++ b/discover_utils/data/handler/nova_db_handler.py
@@ -493,26 +493,27 @@ class AnnotationHandler(IHandler, NovaDBHandler):
             large ``AnnotationData`` payload is only read for the matched annotation.
             Mirrors the id-resolution pattern used in ``save``.
         """
-        db = self.client[dataset]
+        db = self._require_client()[dataset]
 
-        # resolve names -> ids (indexed single-document lookups)
-        scheme_doc = db[SCHEME_COLLECTION].find_one({"name": scheme})
+        # resolve names -> ids (indexed single-document lookups, ids only)
+        scheme_id = db[SCHEME_COLLECTION].find_one({"name": scheme}, {"_id": 1})
         session_id = db[SESSION_COLLECTION].find_one({"name": session}, {"_id": 1})
         role_id = db[ROLE_COLLECTION].find_one({"name": role}, {"_id": 1})
         annotator_id = db[ANNOTATOR_COLLECTION].find_one({"name": annotator}, {"_id": 1})
 
-        if not (scheme_doc and session_id and role_id and annotator_id):
+        if not (scheme_id and session_id and role_id and annotator_id):
             return {}
 
         query = {
             "session_id": session_id["_id"],
             "annotator_id": annotator_id["_id"],
             "role_id": role_id["_id"],
-            "scheme_id": scheme_doc["_id"],
+            "scheme_id": scheme_id["_id"],
         }
 
-        # projected reads (e.g. existence check in save) only need annotation fields
-        if project:
+        # projected reads (e.g. existence check in save) only need annotation fields -
+        # skip the data/scheme document fetches entirely
+        if project is not None:
             anno = db[ANNOTATION_COLLECTION].find_one(query, project)
             if not anno:
                 return {}
@@ -524,6 +525,13 @@ class AnnotationHandler(IHandler, NovaDBHandler):
 
         # fetch the annotation data payload only for the matched annotation
         data_doc = db[ANNOTATION_DATA_COLLECTION].find_one({"_id": anno["data_id"]})
+        if not data_doc:
+            # orphaned annotation (no data) - treat as not found for consistent
+            # FileNotFoundError handling upstream
+            return {}
+
+        # fetch the full scheme document (by id, indexed) only on the non-projected path
+        scheme_doc = db[SCHEME_COLLECTION].find_one({"_id": scheme_id["_id"]})
 
         # reproduce the previous aggregate output shape for the caller
         anno["data"] = [data_doc]

--- a/discover_utils/data/handler/nova_db_handler.py
+++ b/discover_utils/data/handler/nova_db_handler.py
@@ -337,11 +337,27 @@ class NovaDBHandler:
                 return []
             pipeline.append({"$match": {"session_id": session_doc["_id"]}})
 
+        def name_lookup(from_coll, local_field, as_field):
+            # $lookup pipeline form: project only `name` inside the join so the
+            # (potentially large) joined documents - e.g. a scheme's labels/attributes -
+            # are never pulled, keeping this query metadata-only.
+            return {
+                "$lookup": {
+                    "from": from_coll,
+                    "let": {"fid": f"${local_field}"},
+                    "pipeline": [
+                        {"$match": {"$expr": {"$eq": ["$_id", "$$fid"]}}},
+                        {"$project": {"name": 1, "_id": 0}},
+                    ],
+                    "as": as_field,
+                }
+            }
+
         pipeline += [
-            {"$lookup": {"from": SESSION_COLLECTION, "localField": "session_id", "foreignField": "_id", "as": "session"}},
-            {"$lookup": {"from": ANNOTATOR_COLLECTION, "localField": "annotator_id", "foreignField": "_id", "as": "annotator"}},
-            {"$lookup": {"from": ROLE_COLLECTION, "localField": "role_id", "foreignField": "_id", "as": "role"}},
-            {"$lookup": {"from": SCHEME_COLLECTION, "localField": "scheme_id", "foreignField": "_id", "as": "scheme"}},
+            name_lookup(SESSION_COLLECTION, "session_id", "session"),
+            name_lookup(ANNOTATOR_COLLECTION, "annotator_id", "annotator"),
+            name_lookup(ROLE_COLLECTION, "role_id", "role"),
+            name_lookup(SCHEME_COLLECTION, "scheme_id", "scheme"),
         ]
         pipeline.append(
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dynamic = ["version"]
 decord = ["eva-decord >= 0.6.1"]
 pymovie = ["pymovie"]
 pyav = ["pyav"]
+test = ["pytest"]
 
 
 

--- a/tests/test_nova_db_handler.py
+++ b/tests/test_nova_db_handler.py
@@ -1,0 +1,245 @@
+"""Tests for NovaDBHandler exploration queries and the optimized annotation load path.
+
+Mock-based (unittest.mock), matching the style of test_file_uri_resolution.py. These tests
+validate the *call shape* of the queries (which collection, which field/projection/pipeline,
+how results are mapped) - they do not exercise real MongoDB semantics. Equivalence of the
+optimized _load_annotation against the old aggregate pipeline is verified manually against a
+real database (see plan).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from discover_utils.data.handler.nova_db_handler import (
+    NovaDBHandler,
+    AnnotationHandler,
+    SCHEME_COLLECTION,
+    ROLE_COLLECTION,
+    ANNOTATOR_COLLECTION,
+    STREAM_COLLECTION,
+    SESSION_COLLECTION,
+    ANNOTATION_COLLECTION,
+    ANNOTATION_DATA_COLLECTION,
+)
+
+
+def _make_handler(handler_cls=NovaDBHandler):
+    """Build a handler whose client[dataset][collection] returns a stable per-collection mock.
+
+    Returns (handler, client, collections) where `collections` is a dict lazily populated
+    with one MagicMock per collection name accessed.
+    """
+    handler = handler_cls()
+    collections = {}
+    db = MagicMock()
+    db.__getitem__.side_effect = lambda name: collections.setdefault(name, MagicMock())
+    client = MagicMock()
+    client.__getitem__.return_value = db
+    handler._client = client
+    return handler, client, collections, db
+
+
+# ---------------------------------------------------------------------------
+# Connection guard
+# ---------------------------------------------------------------------------
+
+class TestRequireClient:
+    def test_raises_when_not_connected(self):
+        handler = NovaDBHandler()  # no connection params -> _client stays None
+        with pytest.raises(ConnectionError):
+            handler.list_roles("ds")
+
+
+# ---------------------------------------------------------------------------
+# list_datasets
+# ---------------------------------------------------------------------------
+
+class TestListDatasets:
+    def test_filters_system_dbs_and_non_nova(self):
+        handler = NovaDBHandler()
+        client = MagicMock()
+        client.list_database_names.return_value = ["admin", "config", "local", "nova_ds", "other"]
+
+        nova_db = MagicMock()
+        nova_db.list_collection_names.return_value = [SESSION_COLLECTION, SCHEME_COLLECTION]
+        other_db = MagicMock()
+        other_db.list_collection_names.return_value = ["something_else"]
+        client.__getitem__.side_effect = lambda name: {"nova_ds": nova_db, "other": other_db}[name]
+        handler._client = client
+
+        result = handler.list_datasets()  # nova_only=True default
+        assert result == ["nova_ds"]
+
+    def test_nova_only_false_keeps_all_non_system(self):
+        handler = NovaDBHandler()
+        client = MagicMock()
+        client.list_database_names.return_value = ["admin", "config", "local", "nova_ds", "other"]
+        handler._client = client
+
+        result = handler.list_datasets(nova_only=False)
+        assert result == ["nova_ds", "other"]
+        # must not probe collections when nova_only is False
+        client.__getitem__.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# distinct-based enumeration
+# ---------------------------------------------------------------------------
+
+class TestDistinctEnumeration:
+    @pytest.mark.parametrize(
+        "method, collection",
+        [
+            ("list_sessions", SESSION_COLLECTION),
+            ("list_scheme_names", SCHEME_COLLECTION),
+            ("list_roles", ROLE_COLLECTION),
+            ("list_annotators", ANNOTATOR_COLLECTION),
+        ],
+    )
+    def test_distinct_on_name(self, method, collection):
+        handler, client, collections, db = _make_handler()
+        coll_mock = collections.setdefault(collection, MagicMock())
+        coll_mock.distinct.return_value = ["a", "b"]
+
+        result = getattr(handler, method)("ds")
+
+        client.__getitem__.assert_called_with("ds")
+        coll_mock.distinct.assert_called_once_with("name")
+        assert result == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# projection-based metadata listing
+# ---------------------------------------------------------------------------
+
+class TestMetadataListing:
+    def test_list_schemes_projection(self):
+        handler, client, collections, db = _make_handler()
+        coll = collections.setdefault(SCHEME_COLLECTION, MagicMock())
+        coll.find.return_value = [{"name": "transcript", "type": "FREE"}]
+
+        result = handler.list_schemes("ds")
+
+        coll.find.assert_called_once_with({}, {"name": 1, "type": 1, "_id": 0})
+        assert result == [{"name": "transcript", "type": "FREE"}]
+
+    def test_list_streams_metadata_only(self):
+        handler, client, collections, db = _make_handler()
+        coll = collections.setdefault(STREAM_COLLECTION, MagicMock())
+        coll.find.return_value = [{"name": "audio", "type": "feature", "sr": 16000}]
+
+        result = handler.list_streams("ds")
+
+        args, _ = coll.find.call_args
+        assert args[0] == {}
+        projection = args[1]
+        # metadata fields projected, no file payload
+        assert projection["name"] == 1 and projection["sr"] == 1 and projection["dimlabels"] == 1
+        assert result == [{"name": "audio", "type": "feature", "sr": 16000}]
+
+
+# ---------------------------------------------------------------------------
+# list_annotations - metadata-only aggregate (no AnnotationData lookup)
+# ---------------------------------------------------------------------------
+
+class TestListAnnotations:
+    def _pipeline_of(self, collections):
+        coll = collections[ANNOTATION_COLLECTION]
+        (pipeline,), _ = coll.aggregate.call_args
+        return pipeline
+
+    def test_omits_annotation_data_lookup(self):
+        handler, client, collections, db = _make_handler()
+        coll = collections.setdefault(ANNOTATION_COLLECTION, MagicMock())
+        coll.aggregate.return_value = [
+            {"session": "s1", "annotator": "a", "role": "r", "scheme": "sc",
+             "isFinished": True, "isLocked": False}
+        ]
+
+        result = handler.list_annotations("ds")
+
+        pipeline = self._pipeline_of(collections)
+        lookups = [s["$lookup"]["from"] for s in pipeline if "$lookup" in s]
+        assert lookups == [SESSION_COLLECTION, ANNOTATOR_COLLECTION, ROLE_COLLECTION, SCHEME_COLLECTION]
+        assert ANNOTATION_DATA_COLLECTION not in lookups  # the lazy-load win
+        # no session filter -> no $match stage
+        assert not any("$match" in s for s in pipeline)
+        assert result[0]["scheme"] == "sc"
+
+    def test_session_filter_adds_match(self):
+        handler, client, collections, db = _make_handler()
+        coll = collections.setdefault(ANNOTATION_COLLECTION, MagicMock())
+        coll.aggregate.return_value = []
+
+        handler.list_annotations("ds", session="s1")
+
+        pipeline = self._pipeline_of(collections)
+        matches = [s["$match"] for s in pipeline if "$match" in s]
+        assert matches == [{"session.name": "s1"}]
+
+
+# ---------------------------------------------------------------------------
+# _load_annotation optimization (id-resolution instead of collection-wide $lookup)
+# ---------------------------------------------------------------------------
+
+class TestLoadAnnotationOptimized:
+    def _seed_ids(self, collections):
+        collections.setdefault(SCHEME_COLLECTION, MagicMock()).find_one.return_value = {"_id": "scheme1"}
+        collections.setdefault(SESSION_COLLECTION, MagicMock()).find_one.return_value = {"_id": "sess1"}
+        collections.setdefault(ROLE_COLLECTION, MagicMock()).find_one.return_value = {"_id": "role1"}
+        collections.setdefault(ANNOTATOR_COLLECTION, MagicMock()).find_one.return_value = {"_id": "ann1"}
+
+    def test_default_resolves_ids_then_fetches_data_and_scheme(self):
+        handler, client, collections, db = _make_handler(AnnotationHandler)
+        self._seed_ids(collections)
+        anno_coll = collections.setdefault(ANNOTATION_COLLECTION, MagicMock())
+        anno_coll.find_one.return_value = {"_id": "anno1", "data_id": "data1"}
+        data_coll = collections.setdefault(ANNOTATION_DATA_COLLECTION, MagicMock())
+        data_coll.find_one.return_value = {"_id": "data1", "labels": [1, 2, 3]}
+
+        result = handler._load_annotation("ds", "sess", "ann", "role", "scheme")
+
+        # names resolved by indexed find_one on the right collections
+        collections[SCHEME_COLLECTION].find_one.assert_called_with({"name": "scheme"})
+        collections[SESSION_COLLECTION].find_one.assert_called_with({"name": "sess"}, {"_id": 1})
+        collections[ROLE_COLLECTION].find_one.assert_called_with({"name": "role"}, {"_id": 1})
+        collections[ANNOTATOR_COLLECTION].find_one.assert_called_with({"name": "ann"}, {"_id": 1})
+        # annotation fetched by the four ids
+        anno_coll.find_one.assert_called_once_with(
+            {"session_id": "sess1", "annotator_id": "ann1", "role_id": "role1", "scheme_id": "scheme1"}
+        )
+        # AnnotationData payload fetched only for the matched annotation
+        data_coll.find_one.assert_called_once_with({"_id": "data1"})
+        # caller contract: data/scheme as single-item lists
+        assert result["data"] == [{"_id": "data1", "labels": [1, 2, 3]}]
+        assert result["scheme"] == [{"_id": "scheme1"}]
+
+    def test_project_skips_data_and_scheme_fetch(self):
+        handler, client, collections, db = _make_handler(AnnotationHandler)
+        self._seed_ids(collections)
+        anno_coll = collections.setdefault(ANNOTATION_COLLECTION, MagicMock())
+        anno_coll.find_one.return_value = {"_id": "anno1", "isLocked": False, "data_id": "data1"}
+        data_coll = collections.setdefault(ANNOTATION_DATA_COLLECTION, MagicMock())
+
+        project = {"_id": 1, "isLocked": 1, "data_id": 1}
+        result = handler._load_annotation("ds", "sess", "ann", "role", "scheme", project=project)
+
+        anno_coll.find_one.assert_called_once_with(
+            {"session_id": "sess1", "annotator_id": "ann1", "role_id": "role1", "scheme_id": "scheme1"},
+            project,
+        )
+        data_coll.find_one.assert_not_called()
+        assert "data" not in result and "scheme" not in result
+        assert result == {"_id": "anno1", "isLocked": False, "data_id": "data1"}
+
+    def test_missing_name_returns_empty(self):
+        handler, client, collections, db = _make_handler(AnnotationHandler)
+        self._seed_ids(collections)
+        collections[ROLE_COLLECTION].find_one.return_value = None  # role does not exist
+
+        result = handler._load_annotation("ds", "sess", "ann", "role", "scheme")
+
+        assert result == {}
+        # must not attempt to fetch the annotation if a name did not resolve
+        collections.setdefault(ANNOTATION_COLLECTION, MagicMock()).find_one.assert_not_called()

--- a/tests/test_nova_db_handler.py
+++ b/tests/test_nova_db_handler.py
@@ -160,9 +160,13 @@ class TestListAnnotations:
         result = handler.list_annotations("ds")
 
         pipeline = self._pipeline_of(collections)
-        lookups = [s["$lookup"]["from"] for s in pipeline if "$lookup" in s]
+        lookup_stages = [s["$lookup"] for s in pipeline if "$lookup" in s]
+        lookups = [s["from"] for s in lookup_stages]
         assert lookups == [SESSION_COLLECTION, ANNOTATOR_COLLECTION, ROLE_COLLECTION, SCHEME_COLLECTION]
         assert ANNOTATION_DATA_COLLECTION not in lookups  # the lazy-load win
+        # each join projects only `name` so large payloads (e.g. scheme labels) aren't pulled
+        for s in lookup_stages:
+            assert s["pipeline"][-1] == {"$project": {"name": 1, "_id": 0}}
         # no session filter -> no $match stage
         assert not any("$match" in s for s in pipeline)
         assert result[0]["scheme"] == "sc"

--- a/tests/test_nova_db_handler.py
+++ b/tests/test_nova_db_handler.py
@@ -4,7 +4,7 @@ Mock-based (unittest.mock), matching the style of test_file_uri_resolution.py. T
 validate the *call shape* of the queries (which collection, which field/projection/pipeline,
 how results are mapped) - they do not exercise real MongoDB semantics. Equivalence of the
 optimized _load_annotation against the old aggregate pipeline is verified manually against a
-real database (see plan).
+real database.
 """
 
 from unittest.mock import MagicMock
@@ -27,8 +27,8 @@ from discover_utils.data.handler.nova_db_handler import (
 def _make_handler(handler_cls=NovaDBHandler):
     """Build a handler whose client[dataset][collection] returns a stable per-collection mock.
 
-    Returns (handler, client, collections) where `collections` is a dict lazily populated
-    with one MagicMock per collection name accessed.
+    Returns (handler, client, collections, db) where `collections` is a dict lazily populated
+    with one MagicMock per collection name accessed and `db` is the client[dataset] mock.
     """
     handler = handler_cls()
     collections = {}
@@ -200,8 +200,10 @@ class TestLoadAnnotationOptimized:
 
         result = handler._load_annotation("ds", "sess", "ann", "role", "scheme")
 
-        # names resolved by indexed find_one on the right collections
-        collections[SCHEME_COLLECTION].find_one.assert_called_with({"name": "scheme"})
+        # names resolved by indexed find_one on the right collections (ids only)
+        collections[SCHEME_COLLECTION].find_one.assert_any_call({"name": "scheme"}, {"_id": 1})
+        # full scheme doc fetched by id on the non-projected path
+        collections[SCHEME_COLLECTION].find_one.assert_any_call({"_id": "scheme1"})
         collections[SESSION_COLLECTION].find_one.assert_called_with({"name": "sess"}, {"_id": 1})
         collections[ROLE_COLLECTION].find_one.assert_called_with({"name": "role"}, {"_id": 1})
         collections[ANNOTATOR_COLLECTION].find_one.assert_called_with({"name": "ann"}, {"_id": 1})

--- a/tests/test_nova_db_handler.py
+++ b/tests/test_nova_db_handler.py
@@ -167,16 +167,28 @@ class TestListAnnotations:
         assert not any("$match" in s for s in pipeline)
         assert result[0]["scheme"] == "sc"
 
-    def test_session_filter_adds_match(self):
+    def test_session_filter_matches_session_id_before_lookups(self):
         handler, client, collections, db = _make_handler()
+        collections.setdefault(SESSION_COLLECTION, MagicMock()).find_one.return_value = {"_id": "sess1"}
         coll = collections.setdefault(ANNOTATION_COLLECTION, MagicMock())
         coll.aggregate.return_value = []
 
         handler.list_annotations("ds", session="s1")
 
         pipeline = self._pipeline_of(collections)
-        matches = [s["$match"] for s in pipeline if "$match" in s]
-        assert matches == [{"session.name": "s1"}]
+        # session_id $match must be the FIRST stage, before any $lookup (prunes the join)
+        assert pipeline[0] == {"$match": {"session_id": "sess1"}}
+        collections[SESSION_COLLECTION].find_one.assert_called_once_with({"name": "s1"}, {"_id": 1})
+
+    def test_unknown_session_returns_empty(self):
+        handler, client, collections, db = _make_handler()
+        collections.setdefault(SESSION_COLLECTION, MagicMock()).find_one.return_value = None
+        anno = collections.setdefault(ANNOTATION_COLLECTION, MagicMock())
+
+        result = handler.list_annotations("ds", session="missing")
+
+        assert result == []
+        anno.aggregate.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nova_db_handler.py
+++ b/tests/test_nova_db_handler.py
@@ -247,6 +247,39 @@ class TestLoadAnnotationOptimized:
         assert "data" not in result and "scheme" not in result
         assert result == {"_id": "anno1", "isLocked": False, "data_id": "data1"}
 
+    def test_missing_data_doc_returns_empty(self):
+        handler, client, collections, db = _make_handler(AnnotationHandler)
+        self._seed_ids(collections)
+        collections.setdefault(ANNOTATION_COLLECTION, MagicMock()).find_one.return_value = {
+            "_id": "anno1", "data_id": "data1"
+        }
+        collections.setdefault(ANNOTATION_DATA_COLLECTION, MagicMock()).find_one.return_value = None
+
+        result = handler._load_annotation("ds", "sess", "ann", "role", "scheme")
+        assert result == {}
+
+    def test_missing_data_id_returns_empty(self):
+        handler, client, collections, db = _make_handler(AnnotationHandler)
+        self._seed_ids(collections)
+        # annotation present but data_id missing/null -> no KeyError, returns {}
+        collections.setdefault(ANNOTATION_COLLECTION, MagicMock()).find_one.return_value = {"_id": "anno1"}
+
+        result = handler._load_annotation("ds", "sess", "ann", "role", "scheme")
+        assert result == {}
+
+    def test_missing_scheme_doc_returns_empty(self):
+        handler, client, collections, db = _make_handler(AnnotationHandler)
+        self._seed_ids(collections)
+        # scheme id resolves, but the full scheme doc was deleted afterwards
+        collections[SCHEME_COLLECTION].find_one.side_effect = [{"_id": "scheme1"}, None]
+        collections.setdefault(ANNOTATION_COLLECTION, MagicMock()).find_one.return_value = {
+            "_id": "anno1", "data_id": "data1"
+        }
+        collections.setdefault(ANNOTATION_DATA_COLLECTION, MagicMock()).find_one.return_value = {"_id": "data1"}
+
+        result = handler._load_annotation("ds", "sess", "ann", "role", "scheme")
+        assert result == {}
+
     def test_missing_name_returns_empty(self):
         handler, client, collections, db = _make_handler(AnnotationHandler)
         self._seed_ids(collections)


### PR DESCRIPTION
## What

Adds read-only **exploration queries** to the MongoDB handler and **optimizes the annotation load path**.

### Exploration queries (base `NovaDBHandler`, inherited by all handlers)
Previously every DB read was `find_one({"name": ...})` by exact name — no way to discover what exists. New helpers:

| Method | Returns |
|---|---|
| `list_datasets(nova_only=True)` | dataset names you can read (NOVA datasets only by default; excludes mongo `admin`/`config`/`local`) |
| `list_sessions(dataset)` | session names |
| `list_scheme_names(dataset)` / `list_schemes(dataset)` | scheme names / `{name,type}` metadata |
| `list_roles(dataset)` / `list_annotators(dataset)` | role / annotator names |
| `list_streams(dataset)` | stream metadata only (no file read) |
| `list_annotations(dataset, session=None)` | session/annotator/role/scheme combos + `isFinished`/`isLocked`, **no label payload loaded** |

### Optimization — `_load_annotation`
Was: four collection-wide `$lookup`s over *all* annotations, then `$match` on joined names.
Now: resolve names→ids via indexed `find_one` (same pattern as `save()`), fetch the one annotation by id, read the large `AnnotationData` payload only for that match. Return shape preserved (`data`/`scheme` as single-item lists) so `load()` is unchanged; the projected existence-check path in `save()` skips the data/scheme fetch.

## Tests
`tests/test_nova_db_handler.py` (mock-based, matches existing test style) — 14 tests, full suite green (37 passed). Adds a `test` extra (`pip install -e .[test]`).

> Note: mock tests validate query *call shape*, not real mongo semantics. Pipeline equivalence (old vs new `_load_annotation`) needs a manual real-DB check before merge.

## Out of scope
Merging Annotation/Stream handlers (different signatures + explicit dispatch in `data_manager.py`); access-introspection; mongomock-based equivalence tests.